### PR TITLE
Update nltk to >=3.10 to fix path traversal (CVE-2026-12243)

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -40,4 +40,4 @@ dj-database-url==3.1.*
 # Project
 # -----------------------
 feedparser>=5.2,<6.1
-nltk>=3.9,<3.10
+nltk>=3.10,<3.11


### PR DESCRIPTION
## Summary

Bumps the `nltk` pin from `>=3.9,<3.10` to `>=3.10,<3.11`.

## Vulnerability

`nltk<3.10.0` allows arbitrary file read via path traversal in `nltk.data.load()` through percent-encoded sequences (`%2e%2e` bypasses path validation).

- PYSEC-2026-597 / CVE-2026-12243 — High (CVSS 7.5)
- PYSEC-2026-3583 — fixed in 3.10.0
- PYSEC-2026-3582 — fixed in 3.10.0
- PYSEC-2026-3584 — fixed in 3.10.0

## Change

`requirements/base.txt`: `nltk>=3.9,<3.10` → `nltk>=3.10,<3.11`

## Verification

`pip-audit` before: 4 nltk advisories found.
`pip-audit` after: all 4 nltk advisories cleared.

## Notes

- Remaining advisories in repo (django-allauth 65.13.1 / PYSEC-2026-56) are unrelated and not addressed here.
- Change is manifest-only (requirements.txt); no application logic modified.